### PR TITLE
Cope with unsigned SSM Agent RPM

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -51,13 +51,15 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  - name: fedora33_systemd
-    image: cisagov/docker-fedora33-ansible:latest
-    privileged: yes
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /lib/systemd/systemd
-    pre_build_image: yes
+  # Remove fedora33 for now, since it can't even perform a dnf upgrade
+  # because of GPG signature errors.
+  # - name: fedora33_systemd
+  #   image: cisagov/docker-fedora33-ansible:latest
+  #   privileged: yes
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  #   command: /lib/systemd/systemd
+  #   pre_build_image: yes
   - name: ubuntu_bionic_systemd
     image: geerlingguy/docker-ubuntu1604-ansible:latest
     privileged: yes

--- a/tasks/install_RedHat.yml
+++ b/tasks/install_RedHat.yml
@@ -1,4 +1,7 @@
 ---
 - name: Download and install amazon-ssm-agent rpm package
   dnf:
+    # The amazon-ssm-agent RPM is currently unsigned:
+    # https://github.com/aws/amazon-ssm-agent/issues/235
+    disable_gpg_check: yes
     name: "{{ package_url }}"


### PR DESCRIPTION
## 🗣 Description

This pull request:
* Addresses an issue where `dnf` refuses to install the unsigned SSM Agent RPM
* Removes Fedora 33 from the molecule testing

## 💭 Motivation and Context

`dnf` now refuses to install the unsigned SSM Agent RPM, and Fedora 33 seems to be hosed right now...it can't even perform a `dnf update` because of GPG key issues.  Both these issues must be overcome in order to get this PR approved and merged so that we can build a new FreeIPA AMI for the COOL.

## 🧪 Testing

All pre-commit hooks and molecule tests pass.  I am in the process of building a new FreeIPA image using this branch and will update this paragraph after testing.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
