### PR TITLE
Correct hostname in inventory

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -90,7 +90,7 @@ provisioner:
       force_valid_group_names: always
   inventory:
     host_vars:
-      debian9:
+      debian9_systemd:
         # auto_legacy is still the default behavior until Ansible 2.12
         # is released, but Molecule overrides this and forces the use
         # of auto.


### PR DESCRIPTION
## 🗣 Description

This pull request corrects an erroneous hostname in the `inventory` section of the molecule configuration.

## 💭 Motivation and Context

The name of the Debian 9 host is `debian9_systemd`, not `debian9`.

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
