### PR TITLE
Get rid of include warnings

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # These owners will be the default owners for everything in the
 # repo. Unless a later match takes precedence, these owners will be
 # requested for review when someone opens a pull request.
-* @dav3r @jsf9k
+* @dav3r @jsf9k @mcdonnnj
 
 # These folks own any files in the .github directory at the root of
 # the repository and any of its subdirectories.

--- a/tasks/install_Amazon.yml
+++ b/tasks/install_Amazon.yml
@@ -1,5 +1,5 @@
 ---
 - name: Install amazon-ssm-agent
-  package:
+  ansible.builtin.package:
     name:
       - amazon-ssm-agent

--- a/tasks/install_Debian.yml
+++ b/tasks/install_Debian.yml
@@ -1,4 +1,4 @@
 ---
 - name: Download and install amazon-ssm-agent deb package
-  apt:
+  ansible.builtin.apt:
     deb: "{{ package_url }}"

--- a/tasks/install_RedHat.yml
+++ b/tasks/install_RedHat.yml
@@ -1,6 +1,6 @@
 ---
 - name: Download and install amazon-ssm-agent rpm package
-  dnf:
+  ansible.builtin.dnf:
     # The amazon-ssm-agent RPM is currently unsigned:
     # https://github.com/aws/amazon-ssm-agent/issues/235
     disable_gpg_check: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 # tasks file for amazon-ssm-agent
 
 - name: Load var file with package names based on the OS type
-  include_vars: "{{ lookup('first_found', params) }}"
+  ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
   vars:
     params:
       files:
@@ -24,6 +24,6 @@
         - "{{ role_path }}/tasks"
 
 - name: Enable Amazon SSM Agent service
-  service:
+  ansible.builtin.service:
     name: amazon-ssm-agent
     enabled: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-# tasks file for amazon-ssm-agent
-
 - name: Load var file with package names based on the OS type
   ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
   vars:
@@ -25,5 +23,5 @@
 
 - name: Enable Amazon SSM Agent service
   ansible.builtin.service:
-    name: amazon-ssm-agent
     enabled: yes
+    name: amazon-ssm-agent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
         - "{{ role_path }}/vars"
 
 - name: Load tasks file with install tasks based on the OS type
-  include: "{{ lookup('first_found', params) }}"
+  ansible.builtin.include_tasks: "{{ lookup('first_found', params) }}"
   vars:
     params:
       files:


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Gets rid of a simple `include` directive, which is now deprecated, in favor of an `ansible.builtin.include_tasks` directive
- Modifies the Ansible code to use FQCNs throughout
- Alphabetizes a few module parameters where necessary
- Adds @mcdonnnj as a codeowner

## 💭 Motivation and context ##

- This gets rid of an annoying deprecation warning in our Packer AMI builds, and prevents future breakage.
- FQCNs have been preferred by Ansible for some time now.  I'm not sure how this repository missed the grand cleanup we went through several Krakens ago.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.