### PR TITLE
Prefer a dictionary to ternary logic

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,3 +1,11 @@
 ---
+# A dictionary whose keys are values of the Ansible fact
+# ansible_architecture and whose values are processor architecture for
+# which SSM Agent is to be installed, as specified in the SSM Agent
+# package filename.
+architectures:
+  aarch64: arm64
+  x86_64: amd64
+
 # The URL to the deb package to install for amazon-ssm-agent
-package_url: https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_{{ 'amd64' if ansible_architecture == 'x86_64' else 'arm64' }}/amazon-ssm-agent.deb
+package_url: https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_{{ architectures[ansible_architecture] }}/amazon-ssm-agent.deb

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,3 +1,11 @@
 ---
+# A dictionary whose keys are values of the Ansible fact
+# ansible_architecture and whose values are processor architecture for
+# which SSM Agent is to be installed, as specified in the SSM Agent
+# package filename.
+architectures:
+  aarch64: arm64
+  x86_64: amd64
+
 # The URL to the rpm package to install for amazon-ssm-agent
-package_url: https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_{{ 'amd64' if ansible_architecture == 'x86_64' else 'arm64' }}/amazon-ssm-agent.rpm
+package_url: https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_{{ architectures[ansible_architecture] }}/amazon-ssm-agent.rpm


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes the ternary logic that determines the architecture of the system package to install and instead uses a dictionary.

## 💭 Motivation and context ##

The dictionary can handle more than two cases (should that ever be required) and is cleaner.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.