### PR TITLE
Use the candidate channel when installing via snap on Ubuntu

### DIFF
--- a/tasks/install_Ubuntu.yml
+++ b/tasks/install_Ubuntu.yml
@@ -24,8 +24,11 @@
 # the task until it succeeds.
 - name: Install amazon-ssm-agent via snap
   community.general.snap:
+    # The candidate channel corresponds to the version we get by
+    # installing system packages on the other platforms we support.
+    channel: candidate
     # The version of amazon-ssm-agent currently available in the
-    # stable channel requires this.
+    # stable and candidate channels requires this.
     classic: true
     name:
       - amazon-ssm-agent


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the code to install the SSM Agent snap from the candidate channel on Ubuntu.

## 💭 Motivation and context ##

The version obtained from the candidate channel corresponds to the version we get by installing system packages on the other platforms we support.  There is [an unclear blurb in the AWS documentation about this](https://docs.aws.amazon.com/systems-manager/latest/userguide/agent-install-ubuntu-64-snap.html), which I now understand.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.